### PR TITLE
Revert "Adding core js polyfill support for online editors"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@angular/platform-browser": "~8.2.3",
     "@angular/platform-browser-dynamic": "~8.2.3",
     "@angular/router": "~8.2.3",
-    "core-js": "3.2.1",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -51,12 +51,12 @@
  *  (window as any).__Zone_enable_cross_context_check = true;
  *
  */
-import "core-js/es7/reflect";
 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import "zone.js/dist/zone"; // Included with Angular CLI.
+import 'zone.js/dist/zone';  // Included with Angular CLI.
+
 
 /***************************************************************************************************
  * APPLICATION IMPORTS


### PR DESCRIPTION
Reverts teleporthq/teleport-project-template-angular#3

Reverting this because even after adding polyfills. It is unstable and 99% of the time it's not rendering the output in codesandbox. 